### PR TITLE
Revert "Attempt fix at horizontal split"

### DIFF
--- a/dalme_app/static/css/dalme_public.css
+++ b/dalme_app/static/css/dalme_public.css
@@ -1760,9 +1760,6 @@ div.description[data-collapsed='true'] {
     padding-top: 1rem;
     overflow: scroll;
   }
-  main.collections.inventories.horizontal-split {
-    overflow: unset;
-  }
 
   .content {
     padding: 0 1rem 4rem 1rem;

--- a/templates/dalme_public/inventory.html
+++ b/templates/dalme_public/inventory.html
@@ -259,11 +259,8 @@
       });
       window.eventBus.$on('flipView', data => {
         const node = $('.folios');
-        const main = node.parent().parent();
         if (node.hasClass('vertical-split')) {
           node.removeClass('vertical-split').addClass('horizontal-split');
-          main.toggleClass('vertical-split', false);
-          main.toggleClass('horizontal-split', true);
           node.find('.folio')
             .resizable('destroy')
             .resizableSafe({
@@ -278,8 +275,6 @@
             .css({ width: '' });
         } else {
           node.removeClass('horizontal-split').addClass('vertical-split');
-          main.toggleClass('horizontal-split', false);
-          main.toggleClass('vertical-split', true);
           node.find('.folio')
             .resizable('destroy')
             .resizableSafe({


### PR DESCRIPTION
While testing this, I discovered that the problem this PR was trying to solve is browser specific. The initial code did't work in Chrome (when switching to vertical mode the transcription pane disappeared), but it turns out it works almost fine in Safari (e.g. https://public.dalme.org/collections/inventories/6a0fbaff-19a5-410a-b856-2858df74537e/). I say almost because the pane shows a single line by default, but at least it's there! The new code, which seems to do the same in both browsers, shows the transcription pane after switching, but makes the viewer no longer have a fixed height, so the page scrolls again.